### PR TITLE
fix(bootstrap-03): document submodule-vs-monorepo graphify install paths

### DIFF
--- a/runbooks/RELEASE_PROCESS.md
+++ b/runbooks/RELEASE_PROCESS.md
@@ -28,6 +28,28 @@
 11. Update `CHANGELOG.md`
 12. Create annotated tag and release notes
 
+## Graphify Install Paths
+
+The release and evidence steps above invoke `graphify` via
+`scripts/run_graphify.sh`. If `graphify` is not on `PATH`, install from
+source using the path that matches your consumer layout:
+
+- **Monorepo / authoring checkout** (this repo, or any checkout where the
+  governance source tree is the repo root):
+  ```bash
+  pip install -e ./graphify
+  ```
+- **Submodule consumer** (graphify lives inside the pinned governance
+  submodule at `.governance/ai-dev-governance/graphify`):
+  ```bash
+  pip install -e ./.governance/ai-dev-governance/graphify
+  ```
+- **Optional heavy extras** (Leiden / community detection only):
+  `pip install -e '<path>[cluster]'`.
+
+`scripts/run_graphify.sh` emits both paths in its "graphify not on PATH"
+failure message; follow the one that matches the layout.
+
 ## Required Release Artifacts
 
 - Changelog entry

--- a/scripts/run_graphify.sh
+++ b/scripts/run_graphify.sh
@@ -136,4 +136,16 @@ graphify.sourceRepoTag: ${SOURCE_REPO_TAG:-<unset>}
 EOF
 
 # If the user supplied extra flags, append them. Upstream graphify invocation:
-exec "${GRAPHIFY:-graphify}" "${GRAPHIFY_FLAGS[@]}" "$@"
+GRAPHIFY_BIN="${GRAPHIFY:-graphify}"
+if ! command -v "$GRAPHIFY_BIN" >/dev/null 2>&1; then
+  cat >&2 <<MSG
+[run_graphify] FAIL: '${GRAPHIFY_BIN}' not found on PATH.
+Install from source at the path that matches your consumer layout:
+  monorepo / authoring:   pip install -e ./graphify
+  submodule consumer:     pip install -e ./.governance/ai-dev-governance/graphify
+Optional heavy extras (Leiden / clustering): append '[cluster]' to the path.
+See runbooks/RELEASE_PROCESS.md > Graphify Install Paths.
+MSG
+  exit 1
+fi
+exec "$GRAPHIFY_BIN" "${GRAPHIFY_FLAGS[@]}" "$@"


### PR DESCRIPTION
## Summary
- `runbooks/RELEASE_PROCESS.md`: new "Graphify Install Paths" section with explicit monorepo vs submodule-consumer install commands.
- `scripts/run_graphify.sh`: emit both install paths in the "graphify not on PATH" failure message.

Closes #4

## Test plan
- [ ] `bash -n scripts/run_graphify.sh`
- [ ] On a system with `graphify` absent from PATH, invoke the wrapper; confirm the failure message lists both paths.
- [ ] Runbook section renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)