### PR TITLE
fix(bootstrap-05): document and preflight graphify Python compat range

### DIFF
--- a/runbooks/COMPATIBILITY_MATRIX.md
+++ b/runbooks/COMPATIBILITY_MATRIX.md
@@ -9,6 +9,18 @@
 | v0.2.x             | strict                 | Yes (add `boardReview` to manifest for strict baseline consumers) | — |
 | v0.1.x             | strict                 | No                 | — |
 
+## Python Runtime (graphify / Astaire)
+
+| Component | Declared range (pyproject) | Tested range | Notes |
+|-----------|----------------------------|--------------|-------|
+| graphify  | `>=3.10`                   | 3.11, 3.12   | 3.14 breaks the heavy dep stack (`graspologic` → `gensim`/`numba`/`llvmlite`). Use a dedicated 3.12 venv (`.graphify-venv`) if the repo's primary `.venv` is on 3.13+. |
+| Astaire   | `>=3.10`                   | 3.11, 3.12   | Default consumer wrapper runs via `uv run`; pin interpreter explicitly with `UV_PYTHON=3.12` if the system interpreter is outside the tested range. |
+
+`scripts/run_graphify.sh` preflights the interpreter and fails loudly when it
+is outside the tested range — this is a soft guard that can be overridden with
+`GRAPHIFY_ALLOW_UNTESTED_PYTHON=1` when you need to experiment on a newer
+Python release.
+
 ## Rules
 
 - Minor and patch versions are backward compatible unless explicitly declared otherwise.

--- a/scripts/run_graphify.sh
+++ b/scripts/run_graphify.sh
@@ -21,6 +21,23 @@ EXCEPTIONS="${GOVERNANCE_EXCEPTIONS:-${ROOT_DIR}/docs/governance/exceptions.yaml
 
 [[ -f "$MANIFEST" ]] || die "manifest not found: $MANIFEST"
 
+# ADG-BOOTSTRAP-05 — Python compatibility preflight. Graphify's dep stack is
+# tested against 3.10–3.13; 3.14 breaks the heavy path (numba / llvmlite).
+# Soft guard: override with GRAPHIFY_ALLOW_UNTESTED_PYTHON=1 when intentionally
+# experimenting. See runbooks/COMPATIBILITY_MATRIX.md > Python Runtime.
+PYTHON_BIN="${GRAPHIFY_PYTHON:-python3}"
+if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PY_VER="$("$PYTHON_BIN" -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")' 2>/dev/null || true)"
+  if [[ -n "$PY_VER" && "${GRAPHIFY_ALLOW_UNTESTED_PYTHON:-0}" != "1" ]]; then
+    case "$PY_VER" in
+      3.10|3.11|3.12|3.13) : ;;
+      *)
+        die "graphify tested on Python 3.10–3.13, got ${PY_VER}. Use a dedicated 3.12 venv (e.g. .graphify-venv) or set GRAPHIFY_ALLOW_UNTESTED_PYTHON=1 to bypass. See runbooks/COMPATIBILITY_MATRIX.md > Python Runtime."
+        ;;
+    esac
+  fi
+fi
+
 # Naive YAML extractor for the graphify block. Keeps the wrapper
 # dependency-free (no python/yq requirement at runtime).
 extract_scalar() {


### PR DESCRIPTION
## Summary
- `runbooks/COMPATIBILITY_MATRIX.md`: new "Python Runtime" section — declared vs tested ranges for graphify and Astaire, dedicated-venv workaround.
- `scripts/run_graphify.sh`: interpreter preflight that fails loudly outside 3.10–3.13 with actionable guidance. Override: `GRAPHIFY_ALLOW_UNTESTED_PYTHON=1` or `GRAPHIFY_PYTHON=<path>`.

## Scope note
Tightening `requires-python` in `graphify/pyproject.toml` belongs upstream (safishamsi/graphify) — graphify is a vendored submodule tracking an external project.

Closes #6

## Test plan
- [ ] `bash -n scripts/run_graphify.sh`
- [ ] `GRAPHIFY_PYTHON=python3.14 bash scripts/run_graphify.sh` fails with the documented message.
- [ ] `GRAPHIFY_PYTHON=python3.12 bash scripts/run_graphify.sh` passes preflight.
- [ ] `GRAPHIFY_ALLOW_UNTESTED_PYTHON=1 GRAPHIFY_PYTHON=python3.14 …` bypasses the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)