### PR TITLE
fix(bootstrap-06): reject brace-glob allowlist patterns

### DIFF
--- a/contracts/governance-manifest.example.yaml
+++ b/contracts/governance-manifest.example.yaml
@@ -79,3 +79,20 @@ boardReview:
     minimumAlternatesPerSeat: 1
 updateCadence: monthly
 compatibility: strict
+# Graphify block (v0.6.0+). Drives scripts/run_graphify.sh.
+# NOTE: `allowlist` grammar is fnmatch-style (`*`, `**`, `?`). Brace
+# alternations like `**/*.{c,h}` are NOT expanded and will be rejected by
+# the validator. Write out each extension explicitly.
+graphify:
+  collectionStrategy: split
+  securityMode: restricted
+  sourceRepoTag: example-product
+  allowlist:
+    - "src/**/*.py"
+    - "src/**/*.md"
+    - "lib/**/*.c"
+    - "lib/**/*.cc"
+    - "lib/**/*.cpp"
+    - "lib/**/*.h"
+    - "lib/**/*.hpp"
+    - "docs/**/*.md"

--- a/contracts/governance-manifest.schema.json
+++ b/contracts/governance-manifest.schema.json
@@ -220,7 +220,12 @@
         },
         "allowlist": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1},
+          "description": "Path-glob allowlist for graphify. Grammar: fnmatch-style `*`, `**`, `?`. Brace alternations (`{a,b}`) are NOT supported — expand to explicit entries (e.g. `**/*.c` and `**/*.h` instead of `**/*.{c,h}`).",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "not": {"pattern": "[{}]"}
+          },
           "uniqueItems": true
         },
         "sourceRepoTag": {

--- a/scripts/run_graphify.sh
+++ b/scripts/run_graphify.sh
@@ -70,6 +70,18 @@ DENYLIST=(
 mapfile -t ALLOWLIST < <(extract_allowlist)
 [[ ${#ALLOWLIST[@]} -gt 0 ]] || die "graphify.allowlist empty"
 
+# ADG-BOOTSTRAP-06 — reject brace-glob syntax. The underlying matcher is
+# fnmatch-style (`*`, `**`, `?`) and does not expand `{a,b}` alternations;
+# leaving them in place silently under-matches. Fail loudly so consumers
+# expand to explicit per-extension entries instead.
+for entry in "${ALLOWLIST[@]}"; do
+  case "$entry" in
+    *"{"*"}"*)
+      die "allowlist entry contains unsupported brace glob: '${entry}'. Expand to explicit entries (e.g. '**/*.c' and '**/*.h' instead of '**/*.{c,h}'). See contracts/governance-manifest.example.yaml > graphify.allowlist for supported grammar."
+      ;;
+  esac
+done
+
 # Fail-closed: full mode requires an exception entry matching graphify.full.
 if [[ "$MODE" == "full" ]]; then
   if ! grep -qE '^\s*-\s+(id:|name:).*graphify[._-]full' "$EXCEPTIONS" 2>/dev/null; then


### PR DESCRIPTION
## Summary
- `scripts/run_graphify.sh`: reject allowlist entries containing `{…}` with an actionable message.
- `contracts/governance-manifest.schema.json`: document fnmatch grammar on `graphify.allowlist` and forbid brace characters in items.
- `contracts/governance-manifest.example.yaml`: add a worked graphify block with explicit per-extension patterns.

Closes #7

## Test plan
- [ ] `bash -n scripts/run_graphify.sh`
- [ ] `scripts/validate_governance.sh` still passes.
- [ ] Manifest with `**/*.{c,h}` fails the wrapper with the documented message.
- [ ] Manifest with explicit `**/*.c` and `**/*.h` passes.
- [ ] Schema-aware linters reject brace characters in `graphify.allowlist` items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)