### PR TITLE
Bootstrap: reuse shared Astaire venv in wrapper

### DIFF
--- a/runbooks/SUBMODULE_CONSUMER_RUNBOOK.md
+++ b/runbooks/SUBMODULE_CONSUMER_RUNBOOK.md
@@ -68,9 +68,9 @@ git commit -m "Rollback governance submodule pin"
 
 Every consumer repo that pins `ai-dev-governance` MUST wire Astaire so agents
 can read planning and release artifacts via the port-of-first-resort. This
-section is pin-aware: the wrapper delegates to whichever commit of the Astaire
-submodule `git submodule` has checked out, so a version bump automatically
-picks up the new binary without touching the wrapper.
+section is pin-aware: the wrapper bootstraps a shared repo-local venv from
+whichever commit of the Astaire submodule `git submodule` has checked out, then
+reuses that installed entrypoint for steady-state calls.
 
 ### Step 1 — Create the repo-local wrapper
 
@@ -82,8 +82,25 @@ cat > .astaire/astaire << 'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-exec uv run --project "${REPO_ROOT}/.governance/ai-dev-governance/astaire" \
-  astaire --db "${REPO_ROOT}/.astaire/memory_palace.db" "$@"
+UV_CACHE_DIR_DEFAULT="${REPO_ROOT}/.astaire/.uv-cache"
+UV_PROJECT_ENVIRONMENT_DEFAULT="${REPO_ROOT}/.astaire/.venv"
+ASTAIRE_PROJECT_ROOT="${REPO_ROOT}/.governance/ai-dev-governance/astaire"
+ASTAIRE_DB="${REPO_ROOT}/.astaire/memory_palace.db"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${UV_CACHE_DIR_DEFAULT}}"
+export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-${UV_PROJECT_ENVIRONMENT_DEFAULT}}"
+ASTAIRE_BIN="${ASTAIRE_BIN:-${UV_PROJECT_ENVIRONMENT}/bin/astaire}"
+
+if [[ -x "${ASTAIRE_BIN}" ]]; then
+  exec "${ASTAIRE_BIN}" --db "${ASTAIRE_DB}" "$@"
+fi
+
+mkdir -p "${UV_CACHE_DIR}" "${UV_PROJECT_ENVIRONMENT}"
+uv sync --project "${ASTAIRE_PROJECT_ROOT}" \
+  --directory "${ASTAIRE_PROJECT_ROOT}" \
+  --frozen \
+  --no-dev
+
+exec "${ASTAIRE_BIN}" --db "${ASTAIRE_DB}" "$@"
 EOF
 chmod +x .astaire/astaire
 echo '.astaire/memory_palace.db' >> .gitignore
@@ -91,6 +108,9 @@ echo '.astaire/memory_palace.db' >> .gitignore
 
 Adjust the submodule mount path if the governance submodule is not at
 `.governance/ai-dev-governance`.
+
+This avoids a networked `uv run` resolve path on every Astaire invocation.
+`uv sync` runs only as a bootstrap fallback when `.astaire/.venv` is missing.
 
 ### Step 2 — Initialize and verify
 

--- a/scripts/bootstrap_project.sh
+++ b/scripts/bootstrap_project.sh
@@ -161,8 +161,25 @@ write_astaire_wrapper() {
 set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 GOVERNANCE_MOUNT="${GOVERNANCE_MOUNT:-.governance/ai-dev-governance}"
-exec uv run --project "${REPO_ROOT}/${GOVERNANCE_MOUNT}/astaire" \
-  astaire --db "${REPO_ROOT}/.astaire/memory_palace.db" "$@"
+UV_CACHE_DIR_DEFAULT="${REPO_ROOT}/.astaire/.uv-cache"
+UV_PROJECT_ENVIRONMENT_DEFAULT="${REPO_ROOT}/.astaire/.venv"
+ASTAIRE_PROJECT_ROOT="${REPO_ROOT}/${GOVERNANCE_MOUNT}/astaire"
+ASTAIRE_DB="${REPO_ROOT}/.astaire/memory_palace.db"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${UV_CACHE_DIR_DEFAULT}}"
+export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-${UV_PROJECT_ENVIRONMENT_DEFAULT}}"
+ASTAIRE_BIN="${ASTAIRE_BIN:-${UV_PROJECT_ENVIRONMENT}/bin/astaire}"
+
+if [[ -x "${ASTAIRE_BIN}" ]]; then
+  exec "${ASTAIRE_BIN}" --db "${ASTAIRE_DB}" "$@"
+fi
+
+mkdir -p "${UV_CACHE_DIR}" "${UV_PROJECT_ENVIRONMENT}"
+uv sync --project "${ASTAIRE_PROJECT_ROOT}" \
+  --directory "${ASTAIRE_PROJECT_ROOT}" \
+  --frozen \
+  --no-dev
+
+exec "${ASTAIRE_BIN}" --db "${ASTAIRE_DB}" "$@"
 WRAPPER
     chmod +x "$wrapper"
     info "Created .astaire/astaire wrapper"

--- a/templates/AGENTS_BOOTSTRAP_TEMPLATE.md
+++ b/templates/AGENTS_BOOTSTRAP_TEMPLATE.md
@@ -17,7 +17,9 @@ the next bootstrap run will overwrite it.
 ### Astaire — port-of-first-resort (MANDATORY)
 
 **Where:** `.astaire/astaire` at repo root. This wrapper sets `--db`
-to `.astaire/memory_palace.db` and delegates to the pinned submodule.
+to `.astaire/memory_palace.db`, reuses the shared `.astaire/.venv`
+entrypoint when present, and only bootstraps with `uv sync` if that
+venv is missing.
 **Never** invoke bare `astaire` — it is not on PATH and will use the
 wrong database.
 

--- a/templates/ASTAIRE_CLI_SNIPPET.md
+++ b/templates/ASTAIRE_CLI_SNIPPET.md
@@ -20,9 +20,10 @@ permitted when (a) Astaire has no projection for the target, or
 (b) the read is in service of an edit.
 
 **CLI location:** `.astaire/astaire` (repo root). Always invoke with
-this full path — the wrapper sets `--db` to `.astaire/memory_palace.db`
-and routes to the pinned submodule. Never invoke bare `astaire`; it is
-not on PATH and will not use the correct database.
+this full path — the wrapper sets `--db` to `.astaire/memory_palace.db`,
+reuses the shared `.astaire/.venv` entrypoint, and only falls back to
+`uv sync` bootstrap when that venv is missing. Never invoke bare
+`astaire`; it is not on PATH and will not use the correct database.
 
 ```bash
 .astaire/astaire --help

--- a/validation/fixtures/bootstrap-new/AGENTS.md
+++ b/validation/fixtures/bootstrap-new/AGENTS.md
@@ -12,7 +12,9 @@ loaded in context.
 ### Astaire — port-of-first-resort (MANDATORY)
 
 **Where:** `.astaire/astaire` at repo root. This wrapper sets `--db`
-to `.astaire/memory_palace.db` and delegates to the pinned submodule.
+to `.astaire/memory_palace.db`, reuses the shared `.astaire/.venv`
+entrypoint when present, and only bootstraps with `uv sync` if that
+venv is missing.
 **Never** invoke bare `astaire` — it is not on PATH and will use the
 wrong database.
 

--- a/validation/fixtures/bootstrap-retrofit/AGENTS.md
+++ b/validation/fixtures/bootstrap-retrofit/AGENTS.md
@@ -21,7 +21,9 @@ This content was already here before retrofit. It is preserved verbatim.
 ### Astaire — port-of-first-resort (MANDATORY)
 
 **Where:** `.astaire/astaire` at repo root. This wrapper sets `--db`
-to `.astaire/memory_palace.db` and delegates to the pinned submodule.
+to `.astaire/memory_palace.db`, reuses the shared `.astaire/.venv`
+entrypoint when present, and only bootstraps with `uv sync` if that
+venv is missing.
 **Never** invoke bare `astaire` — it is not on PATH and will use the
 wrong database.
 


### PR DESCRIPTION
Closes #17.

## Summary
- generate a repo-local Astaire wrapper that executes the installed `.astaire/.venv/bin/astaire` entrypoint for steady-state use
- fall back to `uv sync --frozen --no-dev` only when the shared venv is missing
- update the consumer bootstrap runbook and templates to describe the shared-venv behavior accurately

## Why
The previous generated wrapper used `uv run --project ...` on every invocation, which could re-enter build/dependency resolution and trigger network fetches in downstream offline or sandboxed agent sessions even after `.astaire/.venv` was already hydrated.

## Scope
This is an `ai-dev-governance` bootstrap/integration fix rather than an Astaire core CLI change.