### PR TITLE
core(tdr): add Contract Test Hygiene section

### DIFF
--- a/core/AI_ASSISTED_TDR_METHODOLOGY.md
+++ b/core/AI_ASSISTED_TDR_METHODOLOGY.md
@@ -86,6 +86,23 @@ Evidence MUST be stored in declared paths and include:
 - AI assistance MAY draft tests and criteria.
 - AI-only approvals are prohibited for merge/release gates.
 
+## Contract Test Hygiene
+
+- A scenario with ratified acceptance criteria MUST NOT be gated by
+  `skipUnless` (Python), `--gtest_filter` exclusions (C++), or
+  equivalent silent-skip mechanisms.
+- Scenarios pending implementation MUST use the runner's explicit
+  expected-fail surface (`expectedFailure` in unittest, `DISABLED_`
+  prefix in GoogleTest, `xfail` in pytest) so CI reports an explicit
+  state distinguishable from skipped, passing, and failing.
+- Removal of an expected-fail marker MUST be a reviewable diff event;
+  it MUST NOT be coupled to unrelated implementation changes in the
+  same commit.
+- Source-shape proxies (substring/regex scans of implementation source)
+  MAY be used to detect implementation arrival but MUST NOT gate
+  assertions: assertions run unconditionally and produce a real
+  pass/fail.
+
 ## Tooling
 
 This policy is tool-agnostic. Projects choose frameworks and runners through adapters while preserving core policy requirements.


### PR DESCRIPTION
## Summary

Adds a normative **Contract Test Hygiene** section to `core/AI_ASSISTED_TDR_METHODOLOGY.md`:

- Ratified scenarios MUST NOT be gated by `skipUnless` / `--gtest_filter` / equivalents
- Pending-implementation scenarios MUST use the runner's explicit expected-fail surface (`expectedFailure`, `DISABLED_`, `xfail`)
- Removing an expected-fail marker MUST be a reviewable diff event, decoupled from unrelated implementation
- Source-shape proxies MAY detect implementation arrival but MUST NOT gate assertions

## Motivation

Path A tombstone scenarios in consumer projects (cms-pm/cockpit Phase 8) were using `@unittest.skipUnless(_proxy_function(), reason)` to silently skip tests until implementation lands. This produces three failure modes that are invisible in CI:

1. A wrong-symbol implementation causes the proxy to keep returning `False`, so the test stays skipped — drift goes undetected.
2. The proxy regex itself is fragile (e.g. literal-only patterns silently miss macro forms).
3. "Skipped because the implementation hasn't landed" is indistinguishable from "skipped because the environment isn't available" in standard runners.

`expectedFailure` makes "not yet implemented" an **explicit** CI state. Removing the decorator becomes a deliberate, diff-reviewable act when implementation arrives, and a wrong-symbol implementation goes red loudly.

This pattern is the Python analog of GoogleTest's `DISABLED_` prefix and pytest's `xfail`, which the [Avoid Fragile Tests paper](https://github.com/cms-pm/cockpit/blob/main/.governance/Google_Test-_Avoid%20Fragile%20Tests-_Choosing_Between_TEST_TEST_F_and_TEST_P.pdf) cites as the right tool for tracked-but-not-yet-passing scenarios.

## Pilot consumers (cms-pm/cockpit, chunk-8.0t)

The pilot artifacts are already landed in cms-pm/cockpit on `chunk-8.0t-status-additive-and-behavioral`:

- Amendment package: `docs/governance/amendments/2026-05-04-test-hygiene-tdr-amendment-package.md`
- Shared scaffold: `tests/_contract_support.py`
- Predicate pilot: `docs/validation/phase-8/predicates/scn-8.0t.json`
- Reauthored contract test: `tests/test_phase8_0t_sideband_fast_queue_backpressure_contract.py`

The 8.0t contract suite (6/6 green) was the first chunk authored under this rule — SCN-8.0t-03 and SCN-8.0t-05/-06 run unconditionally and produce real pass/fail.

## Stacked PRs (one item per commit, one item per PR)

This is PR 1 of 4 in the test-hygiene amendment package:

| # | Branch | Status |
|---|--------|--------|
| 1 | `tdr/contract-test-hygiene` | **this PR** |
| 2 | `evidence/scenario-status-vocabulary` | draft, depends on #1 |
| 3 | `adapters/hil-sil-predicate-router` | draft, depends on #1, #2 |
| 4 | `astaire/scenario-ledger-collection` | draft, depends on #2 |

## Test plan

- [ ] Confirm the new section renders correctly in the TDR doc
- [ ] Confirm wording is consistent with `core/EVIDENCE_CONTRACT.md` once PR #2 lands
- [ ] Adapter consumers (Claude, Codex) require no change — the rule is tool-agnostic
- [ ] No schema or contract file changes; no test artifacts to run against this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)