### PR TITLE
core(evidence): add Scenario Status Vocabulary

### DIFF
--- a/core/EVIDENCE_CONTRACT.md
+++ b/core/EVIDENCE_CONTRACT.md
@@ -85,6 +85,22 @@ Each release MUST include:
   - Health report with zero blocking findings: `docs/releases/<version>/health-report.md`
   - Both artifacts emitted by `scripts/emit_release_evidence.sh <version>`
 
+## Scenario Status Vocabulary
+
+Acceptance-item `pass/fail status` MUST resolve to one of:
+
+- `not-started`  — no test exists yet
+- `expected-fail` — test exists, implementation pending (tombstone)
+- `passing`       — test exists and passes against current implementation
+- `failing`       — test exists and fails against current implementation
+- `waived`        — covered by an exception/waiver under
+                    `core/EXCEPTIONS_AND_WAIVERS.md`
+
+`skipped` is not a valid terminal state for a scenario with ratified
+acceptance criteria. Runners MAY produce `skipped` as an intermediate
+state (for example, an environment-unavailable HiL probe) but evidence
+records MUST resolve to one of the values above before sign-off.
+
 ## Format
 
 Evidence MAY be stored as markdown, JSON, or YAML if required fields are present and machine-readable summaries are available.


### PR DESCRIPTION
> **Draft — depends on #19** (`tdr/contract-test-hygiene`). Mark ready for review after #19 merges.

## Summary

Adds a normative **Scenario Status Vocabulary** to `core/EVIDENCE_CONTRACT.md`:

- `not-started`, `expected-fail`, `passing`, `failing`, `waived`
- `skipped` is not a valid terminal state for a ratified scenario
- Runners MAY produce `skipped` as an intermediate state (e.g. environment-unavailable HiL probe) but evidence records MUST resolve to one of the five values before sign-off

## Motivation

PR #19 closes the silent-skip gap on the **runtime** side (no `skipUnless` for ratified SCNs). This PR closes the same gap on the **evidence** side. Without an enumerated vocabulary, an evidence ledger can record `skipped` and the gap propagates from CI into the board packet.

The five-state enum mirrors the GoogleTest-paper guidance on tracked-but-not-passing scenarios (`DISABLED_` → `expected-fail`) and the [exceptions/waivers core policy](../core/EXCEPTIONS_AND_WAIVERS.md) (`waived`).

## Pilot consumer

Already wired in cms-pm/cockpit:

```python
# tests/_contract_support.py
def record_scenario(scn_id, status, ...):
    valid = {"not-started", "expected-fail", "passing", "failing", "waived"}
    if status not in valid:
        raise ValueError(f"invalid scenario status {status!r}, expected one of {valid}")
```

The 8.0t contract suite writes JSONL ledger lines validated against this enum to `artifacts/validation/scenario_ledger.jsonl`.

## Stacked PRs

| # | Branch | Status |
|---|--------|--------|
| 1 | `tdr/contract-test-hygiene` | #19 (ready) |
| 2 | `evidence/scenario-status-vocabulary` | **this PR** (draft, depends on #1) |
| 3 | `adapters/hil-sil-predicate-router` | draft, depends on #1, #2 |
| 4 | `astaire/scenario-ledger-collection` | draft, depends on #2 |

## Test plan

- [ ] Confirm wording aligns with the exceptions/waivers core policy
- [ ] Confirm `expected-fail` value is consistent with PR #19's `expectedFailure` rule
- [ ] Confirm Astaire scenario-ledger schema (PR #4) consumes this enum
- [ ] No schema changes in this PR; the enum lives in normative prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)