### PR TITLE
fix(validate_governance): preflight-check ripgrep dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ This repository provides a strict baseline that teams can reuse across projects 
 
 ## Get Started
 
+Prerequisite: `scripts/validate_governance.sh` requires
+[ripgrep](https://github.com/BurntSushi/ripgrep#installation) (`rg`) on
+`PATH`. It preflight-checks for `rg` and fails with a clear message if
+missing.
+
 Recommended consumer entrypoints for the current release:
 
 - stable tag: `v1.1.5`

--- a/scripts/validate_governance.sh
+++ b/scripts/validate_governance.sh
@@ -14,6 +14,8 @@ pass() {
   echo "[PASS] $1"
 }
 
+command -v rg >/dev/null 2>&1 || fail "validate_governance.sh requires ripgrep ('rg') on PATH. Install: https://github.com/BurntSushi/ripgrep#installation"
+
 required_files=(
   "README.md"
   "LICENSE"


### PR DESCRIPTION
## Summary
- `validate_governance.sh` calls `rg` dozens of times with no dependency check, so a Linux consumer clone without ripgrep on `PATH` fails deep inside opaque `rg` invocations instead of a clear error.
- Adds a preflight `command -v rg` check with a clear failure message, and documents ripgrep as a prerequisite in `README.md`.
- Reported by a downstream consumer (nano-assist) alongside two other bugs (grep bracket-expression escaping in `validate_codegraph_wiring.sh`, and mtime-based `negative-stale-index` fixture flakiness) — both of those were confirmed already fixed on `main` as of v1.2.0 (commit `e7b020e`); the reporter was pinned to a stale `1.1.x` ref and just needs a re-pin.

## Test plan
- [x] Simulated `rg` missing from `PATH` (isolated empty-dir `PATH`, direct `/usr/bin/bash` invocation) — confirmed `[FAIL] validate_governance.sh requires ripgrep ('rg') on PATH...` with exit 1.
- [x] Confirmed script still passes normally with `rg` present on `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)