### PR TITLE
Add real JSON Schema validation of manifest example/fixtures

### DIFF
--- a/.github/workflows/governance-consistency.yml
+++ b/.github/workflows/governance-consistency.yml
@@ -13,5 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Install JSON Schema validation dependencies
+        run: python3 -m pip install --quiet jsonschema pyyaml
       - name: Validate governance repository
         run: ./scripts/validate_governance.sh

--- a/scripts/validate_governance.sh
+++ b/scripts/validate_governance.sh
@@ -162,6 +162,79 @@ for k in ("selection", "composition"):
 PY
 pass "Manifest schema keys"
 
+# Real JSON Schema validation (Draft 2020-12) of the canonical manifest
+# example and every top-level fixture manifest against
+# contracts/governance-manifest.schema.json. Nested fixture manifests
+# (validation/fixtures/codegraph/**, validation/fixtures/validators/**)
+# are intentionally partial documents that exercise individual gates,
+# so they are excluded by design.
+#
+# Preflight (same pattern as the rg check above): prefer a python3 that
+# can already import jsonschema + PyYAML; otherwise fall back to a
+# uv-provisioned ephemeral environment (uv is already relied on by
+# scripts/bootstrap_project.sh); fail loudly if neither is available.
+if python3 -c "import jsonschema, yaml" >/dev/null 2>&1; then
+  schema_validation_python() { python3 "$@"; }
+elif command -v uv >/dev/null 2>&1; then
+  schema_validation_python() {
+    uv run --quiet --no-project --with jsonschema --with pyyaml python "$@"
+  }
+else
+  fail "validate_governance.sh requires a JSON Schema validator: install the python3 packages 'jsonschema' and 'pyyaml' (e.g. python3 -m pip install jsonschema pyyaml), or install 'uv' (https://docs.astral.sh/uv/) so an ephemeral validator environment can be provisioned"
+fi
+
+schema_validation_python - <<'PY' || fail "Manifest JSON Schema validation failed (violations listed above)"
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+SCHEMA_PATH = Path("contracts/governance-manifest.schema.json")
+
+
+class ManifestLoader(yaml.SafeLoader):
+    """SafeLoader minus implicit timestamp resolution.
+
+    JSON Schema validates against the JSON data model, where dates are
+    strings. PyYAML would otherwise load unquoted dates (e.g.
+    attestationDate: 2026-05-19) as datetime.date objects and fail
+    "type": "string" checks spuriously.
+    """
+
+
+ManifestLoader.yaml_implicit_resolvers = {
+    key: [(tag, regexp) for tag, regexp in resolvers
+          if tag != "tag:yaml.org,2002:timestamp"]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+schema = json.loads(SCHEMA_PATH.read_text())
+validator_cls = jsonschema.validators.validator_for(schema)
+validator_cls.check_schema(schema)
+validator = validator_cls(schema)
+
+targets = [Path("contracts/governance-manifest.example.yaml")]
+targets += sorted(Path("validation/fixtures").glob("*/governance.yaml"))
+
+violations = 0
+for target in targets:
+    document = yaml.load(target.read_text(), Loader=ManifestLoader)
+    for error in sorted(validator.iter_errors(document),
+                        key=lambda e: list(e.absolute_path)):
+        location = "/".join(str(p) for p in error.absolute_path) or "<root>"
+        print(f"[SCHEMA-VIOLATION] {target}: {location}: {error.message}",
+              file=sys.stderr)
+        violations += 1
+
+if violations:
+    print(f"[SCHEMA-VIOLATION] {violations} violation(s) against "
+          f"{SCHEMA_PATH} (Draft 2020-12)", file=sys.stderr)
+    raise SystemExit(1)
+PY
+pass "Manifest JSON Schema validation (example + fixtures, Draft 2020-12)"
+
 if rg -n "^graphify:" contracts validation governance.yaml >/tmp/adg_graphify_manifest_hits.txt; then
   cat /tmp/adg_graphify_manifest_hits.txt >&2
   fail "Graphify manifest blocks are not supported in ADG"

--- a/validation/CONSISTENCY_RULES.md
+++ b/validation/CONSISTENCY_RULES.md
@@ -20,6 +20,16 @@
 
 1. `contracts/governance-manifest.schema.json` must exist.
 2. `contracts/governance-manifest.example.yaml` must include required keys.
+   In addition, the example and every top-level fixture manifest
+   (`validation/fixtures/*/governance.yaml`) MUST validate against
+   `contracts/governance-manifest.schema.json` under JSON Schema
+   Draft 2020-12. `scripts/validate_governance.sh` enforces this with a
+   real schema-validation pass (jsonschema + PyYAML, uv fallback), so
+   schema/example/fixture drift fails loudly instead of surviving
+   releases. Nested fixture manifests under
+   `validation/fixtures/codegraph/**` and
+   `validation/fixtures/validators/**` are intentionally partial gate
+   fixtures and are excluded from this full-document pass.
 3. Strict baseline examples must declare `automation`, `boardReview.selection`, and `boardReview.composition`.
 4. Board member/composition/finding/decision/handoff schemas must exist.
 5. Strict Claude/Codex manifests must declare `tooling/rtk`.


### PR DESCRIPTION
## Summary

- Adds a real JSON Schema (Draft 2020-12) validation pass to `scripts/validate_governance.sh` that validates `contracts/governance-manifest.example.yaml` and every top-level `validation/fixtures/*/governance.yaml` (consumer-astaire, embedded-missing-evidence, mvp, production, prototype, and any future fixtures) against `contracts/governance-manifest.schema.json`, failing loudly with per-path `[SCHEMA-VIOLATION]` messages on any drift.
- Nested fixture manifests under `validation/fixtures/codegraph/**` and `validation/fixtures/validators/**` are intentionally partial documents that exercise individual gates, so they are excluded by design (documented in the script comment and in `validation/CONSISTENCY_RULES.md`).
- Validator selection follows the existing `rg` preflight pattern: prefer a `python3` that can already import `jsonschema` + `PyYAML`; otherwise fall back to a `uv`-provisioned ephemeral environment (`uv` is already relied on by `scripts/bootstrap_project.sh`); `fail()` loudly with install guidance when neither is available. No new heavyweight dependency is introduced.
- YAML is loaded with implicit timestamp resolution disabled so unquoted dates (e.g. `attestationDate: 2026-05-19`) validate as strings per the JSON data model the schema targets, instead of failing `"type": "string"` spuriously.
- `.github/workflows/governance-consistency.yml` installs `jsonschema`/`pyyaml` so CI exercises the direct-python path.
- `validation/CONSISTENCY_RULES.md` Contract Rules updated to document the new gate.

## Test plan

- [x] `./scripts/validate_governance.sh` passes end-to-end from a clean worktree off `main` (`[PASS] Manifest JSON Schema validation (example + fixtures, Draft 2020-12)` plus all pre-existing checks).
- [x] Negative test: reintroducing the historical `analyzerDeclaration` stray `additionalProperties: false` bug from issue #30 makes the run fail with `[SCHEMA-VIOLATION] contracts/governance-manifest.example.yaml: analyzerDeclaration: Additional properties are not allowed ('structured' was unexpected)` and exit 1.
- [x] `bash -n scripts/validate_governance.sh` clean.
- [x] uv-fallback path exercised locally (host python3 has neither `jsonschema` nor `yaml` importable).
- [ ] CI `governance-consistency` workflow exercises the direct-python path on this PR.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)