### PR TITLE
chore(release): sync manifest governanceVersion to v1.2.3

### DIFF
--- a/contracts/governance-manifest.example.yaml
+++ b/contracts/governance-manifest.example.yaml
@@ -1,5 +1,5 @@
 apiVersion: ai-dev-governance/v1
-governanceVersion: v1.2.1
+governanceVersion: v1.2.3
 profile: strict-baseline+embedded
 adapters:
   - providers/codex

--- a/validation/fixtures/mvp/governance.yaml
+++ b/validation/fixtures/mvp/governance.yaml
@@ -1,5 +1,5 @@
 apiVersion: ai-dev-governance/v1
-governanceVersion: v1.2.1
+governanceVersion: v1.2.3
 profile: strict-baseline+embedded
 adapters:
   - providers/claude

--- a/validation/fixtures/production/governance.yaml
+++ b/validation/fixtures/production/governance.yaml
@@ -1,5 +1,5 @@
 apiVersion: ai-dev-governance/v1
-governanceVersion: v1.2.1
+governanceVersion: v1.2.3
 profile: strict-baseline+embedded
 adapters:
   - providers/codex

--- a/validation/fixtures/prototype/governance.yaml
+++ b/validation/fixtures/prototype/governance.yaml
@@ -1,5 +1,5 @@
 apiVersion: ai-dev-governance/v1
-governanceVersion: v1.2.1
+governanceVersion: v1.2.3
 profile: strict-baseline
 adapters:
   - providers/codex


### PR DESCRIPTION
Completes the 1.2.3 release: `validate_governance.sh` requires `contracts/governance-manifest.example.yaml` and the prototype/mvp/production fixtures to declare the VERSION value; the 1.2.3 bump (PR #34) missed them, leaving the tag internally inconsistent (validation fails at v1.2.3 as first cut). The v1.2.3 tag will be re-cut on the merged tip as part of the same release operation — it is minutes old with no external consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)